### PR TITLE
Added more docker image tags

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,5 +3,15 @@ steps:
     id: DEPLOY
     args: ['-Ddocker.image.prefix=gcr.io/ceres-dev-222017', 'package', 'jib:dockerBuild']
 
+# Tagging the image for a more specific image can be used
+  - name: 'gcr.io/cloud-builders/docker'
+    id: TAG_IMAGE_WITH_BRANCH_NAME
+    args: ['tag', 'gcr.io/ceres-dev-222017/metrics-ingestion-service:latest', 'gcr.io/ceres-dev-222017/metrics-ingestion-service:$BRANCH_NAME']
+  - name: 'gcr.io/cloud-builders/docker'
+    id: TAG_IMAGE_WITH_SHORT_SHA
+    args: ['tag', 'gcr.io/ceres-dev-222017/metrics-ingestion-service:latest', 'gcr.io/ceres-dev-222017/metrics-ingestion-service:$SHORT_SHA']
+
 images:
   - 'gcr.io/ceres-dev-222017/metrics-ingestion-service'
+  - 'gcr.io/ceres-dev-222017/metrics-ingestion-service:$BRANCH_NAME'
+  - 'gcr.io/ceres-dev-222017/metrics-ingestion-service:$SHORT_SHA'


### PR DESCRIPTION
# Resolves
There is a need for more than just the `:latest` tag for this project. This PR adds the branch and the short commit sha as available options when tagging the current docker builds.

## gotchas
Whenever a `/` (slash) is put inside a branch name (ie. `dave/cool_feature1`) then the build will fail. The branch name needs to be consistent with Docker requirements:

> A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
https://docs.docker.com/engine/reference/commandline/tag/