### PR TITLE
Add instance back, but rework how the strings are processed.

### DIFF
--- a/src/main/java/com/rackspacecloud/metrics/ingestionservice/influxdb/InfluxDBHelper.java
+++ b/src/main/java/com/rackspacecloud/metrics/ingestionservice/influxdb/InfluxDBHelper.java
@@ -15,6 +15,7 @@ import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -307,7 +308,7 @@ public class InfluxDBHelper {
         long startTime = System.currentTimeMillis();
         try {
             influxDB.write(databaseName, retPolicyName, InfluxDB.ConsistencyLevel.ONE, TimeUnit.SECONDS, payload);
-            backupService.writeToBackup(payload, databaseName, retPolicyName);
+            backupService.writeToBackup(payload, new URL(baseUrl), databaseName, retPolicyName);
         }
         catch(InfluxDBException.PointsBeyondRetentionPolicyException ex) {
             log.error("Write failed for the payload. baseURL: [{}], databaseName: [{}], ret-policy: [{}]",

--- a/src/main/java/com/rackspacecloud/metrics/ingestionservice/influxdb/providers/LineProtocolBackupService.java
+++ b/src/main/java/com/rackspacecloud/metrics/ingestionservice/influxdb/providers/LineProtocolBackupService.java
@@ -1,6 +1,7 @@
 package com.rackspacecloud.metrics.ingestionservice.influxdb.providers;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.zip.GZIPOutputStream;
 
 /**
@@ -18,11 +19,12 @@ public interface LineProtocolBackupService {
     /**
      * A helper method for accessing the backup service
      * @param payload The payload (line protocol payload that can be used for extracting a timestamp)
+     * @param instanceURL The URL of the influxdb instance
      * @param database Database name used for the payload on the database instance
      * @param retentionPolicy Retention policy name on the database instance
      * @throws IOException
      */
-    void writeToBackup(String payload, String database, String retentionPolicy) throws IOException;
+    void writeToBackup(String payload, URL instanceURL, String database, String retentionPolicy) throws IOException;
 
     /**
      * Flushes and closes all buffers to the implemented backend and clears any caching.

--- a/src/test/java/com/rackspacecloud/metrics/ingestionservice/GCLineProtocolBackupServiceIntegrationTests.java
+++ b/src/test/java/com/rackspacecloud/metrics/ingestionservice/GCLineProtocolBackupServiceIntegrationTests.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.zip.GZIPOutputStream;
 
 @RunWith(SpringRunner.class)
@@ -61,7 +62,7 @@ public class GCLineProtocolBackupServiceIntegrationTests {
                         "for a Google service account, but is " + value,
                         value != null);
 
-        backupService.writeToBackup("testPayload11 1557777267",
+        backupService.writeToBackup("testPayload11 1557777267", new URL("https://test-influx.com:8080"),
                 "test-db", "test-policy");
 
         backupService.flush();

--- a/src/test/java/com/rackspacecloud/metrics/ingestionservice/GCLineProtocolBackupServiceTests.java
+++ b/src/test/java/com/rackspacecloud/metrics/ingestionservice/GCLineProtocolBackupServiceTests.java
@@ -19,6 +19,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -58,10 +61,10 @@ public class GCLineProtocolBackupServiceTests {
     }
 
     @Test
-    public void backupServiceGetProperName() {
+    public void backupServiceGetProperName() throws MalformedURLException, UnsupportedEncodingException {
         assertThat(GCLineProtocolBackupService.getBackupLocation("testPayload 1557777267",
-                "myDB", "1440h"))
-                        .matches("myDB/1440h/20190513");
+                new URL("https://influx-test.com:8080"), "myDB", "1440h"))
+                        .matches("influx-test.com/myDB/1440h/20190513");
     }
 
     @Test
@@ -118,23 +121,30 @@ public class GCLineProtocolBackupServiceTests {
 
     // This test will fail when the cache is not working properly, i.e. re-issuing multiple files instead of caching.
     @Test
-    public void testServiceTwoDbInstances() throws IOException {
+    public void testServiceTwoDbInstances() throws IOException, InterruptedException {
         backupService.writeToBackup("testPayload11 1557777267",
+                new URL("https://influx-test1.com:8080"),
                 "myDB1", "1440h");
         backupService.writeToBackup("testPayload12 1557777268",
+                new URL("https://influx-test1.com:8080"),
                 "myDB1", "1440h");
         backupService.writeToBackup("testPayload13 1557777269",
+                new URL("https://influx-test1.com:8080"),
                 "myDB1", "1440h");
 
         backupService.writeToBackup("testPayload21 1557777267",
+                new URL("https://influx-test2.com:8080"),
                 "myDB2", "1440h");
         backupService.writeToBackup("testPayload22 1557777268",
+                new URL("https://influx-test2.com:8080"),
                 "myDB2", "1440h");
         backupService.writeToBackup("testPayload23 1557777269",
+                new URL("https://influx-test2.com:8080"),
                 "myDB2", "1440h");
 
         backupService.flush();
-        
+
+        TimeUnit.SECONDS.sleep(1);
 
         Iterator<Blob> iterator = storage.list(backupProperties.getGcsBackupBucket()).getValues().iterator();
 


### PR DESCRIPTION
This adds the instance name back (it's needed for when we try to restore a specific instance), but does the processing in a different way (otherwise running into issues with how the cloud buckets work).