### PR TITLE
Fixed profile name from 'dev' to 'development'

### DIFF
--- a/src/main/java/com/rackspacecloud/metrics/ingestionservice/influxdb/config/StorageConfiguration.java
+++ b/src/main/java/com/rackspacecloud/metrics/ingestionservice/influxdb/config/StorageConfiguration.java
@@ -23,7 +23,7 @@ public class StorageConfiguration {
     }
 
     @Bean
-    @Profile({"test", "dev"})
+    @Profile({"test", "development"})
     public Storage memStorage(){
         // In-memory storage for testing
         log.info("Configuring local storage for testing");


### PR DESCRIPTION
Profile name `dev` was causing `development` profile based code to fail. 