### PR TITLE
Add dml context

### DIFF
--- a/src/main/java/com/rackspacecloud/metrics/ingestionservice/influxdb/GCLineProtocolBackupService.java
+++ b/src/main/java/com/rackspacecloud/metrics/ingestionservice/influxdb/GCLineProtocolBackupService.java
@@ -80,7 +80,7 @@ public class GCLineProtocolBackupService implements LineProtocolBackupService {
      * @param location the location within the bucket (directory) where blobs will be written to
      * @return the cached reference to the gzip output stream for that blob
      */
-    @Cacheable(cacheNames = "lineProtocolBackupWriter", key="location")
+    @Cacheable(cacheNames = "lineProtocolBackupWriter", key="#location")
     public GZIPOutputStream getBackupStream(String location, String database, String retentionPolicy) throws IOException {
         Assert.hasText(location, "location must contain text");
         String fileName = location + "/" + UUID.randomUUID().toString() + ".gz";

--- a/src/main/java/com/rackspacecloud/metrics/ingestionservice/influxdb/providers/LineProtocolBackupService.java
+++ b/src/main/java/com/rackspacecloud/metrics/ingestionservice/influxdb/providers/LineProtocolBackupService.java
@@ -14,7 +14,7 @@ public interface LineProtocolBackupService {
      * @return A backup stream where line protocol lines can be written to
      * @throws IOException
      */
-    GZIPOutputStream getBackupStream(String location) throws IOException;
+    GZIPOutputStream getBackupStream(String location, String database, String retentionPolicy) throws IOException;
 
     /**
      * A helper method for accessing the backup service

--- a/src/test/java/com/rackspacecloud/metrics/ingestionservice/GCLineProtocolBackupServiceIntegrationTests.java
+++ b/src/test/java/com/rackspacecloud/metrics/ingestionservice/GCLineProtocolBackupServiceIntegrationTests.java
@@ -49,7 +49,7 @@ public class GCLineProtocolBackupServiceIntegrationTests {
 
     @Test
     public void testSimpleBackupIntegration() throws IOException {
-        GZIPOutputStream outputStream = backupService.getBackupStream("simple-test");
+        GZIPOutputStream outputStream = backupService.getBackupStream("simple-test", "db0", "rp0");
         outputStream.write("test".getBytes());
         outputStream.close();
     }


### PR DESCRIPTION
A small change that adds database and retention policy to the backup files themselves. This is required so that influx CLI can direcly import the files without manipulating the files first. This will allow us to get the restore complexity to two simple and deterministic bash commands.