### PR TITLE
Simplified spring boot run to include raw-data-consumer profile

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+# Resolves
+
+<Jira or Github issue reference(s)>
+
+# What
+
+<What is this PR is trying to accomplish?>
+
+# How
+
+<How is the PR designed to solve the problem?>
+
+## How to test
+
+<instructions for verifying the changes specific to this PR>
+
+# Why
+
+<Why was the final approach taken? Were alternatives considered?>
+
+# TODO
+
+<outstanding tasks before this PR is considered 'ready'>

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -38,8 +38,11 @@ steps:
   - id: TESTING
     waitFor:
       - DECRYPT_INTEGRATION_TEST_CREDENTIALS
-    name: 'gcr.io/cloud-builders/mvn'
-    args: ['test']
+    name: 'maven:3.6-jdk-11'
+    args:
+      - mvn
+      - -B
+      - test
     env:
       - 'GOOGLE_APPLICATION_CREDENTIALS=/root/serviceaccount.json'
     volumes:

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,9 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<profiles>development,raw-data-consumer</profiles>
+				</configuration>
 			</plugin>
 			<!-- avro-maven-plugin -->
 			<plugin>
@@ -147,26 +150,6 @@
 						<configuration>
 							<sourceDirectory>${project.basedir}/src/main/resources/avro/</sourceDirectory>
 							<stringType>String</stringType>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<!--force discovery of generated classes-->
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.0.0</version>
-				<executions>
-					<execution>
-						<id>add-source</id>
-						<phase>generate-sources</phase>
-						<goals>
-							<goal>add-source</goal>
-						</goals>
-						<configuration>
-							<sources>
-								<source>target/generated-sources/avro</source>
-							</sources>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
Since the default activation of `development` spring profile results in a failure to load the application context, the maven spring boot run config now includes the typical profile `raw-data-consumer`.