### PR TITLE
Consolidated application.properties into application.yaml

### DIFF
--- a/src/main/java/com/rackspacecloud/metrics/ingestionservice/influxdb/providers/DevTestTenantRouteProvider.java
+++ b/src/main/java/com/rackspacecloud/metrics/ingestionservice/influxdb/providers/DevTestTenantRouteProvider.java
@@ -20,14 +20,7 @@ public class DevTestTenantRouteProvider implements RouteProvider {
      */
     @Override
     public TenantRoutes getRoute(String tenantId, String measurement, RestTemplate restTemplate) throws Exception {
-        String requestUrl = String.format("%s/%s/%s", tenantRoutingServiceUrl, tenantId, measurement);
-
-        try {
-            return getStubbedRoutes(tenantId, measurement);
-        }
-        catch (Exception e) {
-            throw new Exception(String.format("Exception thrown for requestUrl [%s]", requestUrl), e);
-        }
+        return getStubbedRoutes(tenantId, measurement);
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.profiles.active=raw-data-consumer,rollup-data-consumer,test

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,7 +3,8 @@ server:
 spring:
   application:
     name: ceres-ingestion-service
-
+  profiles:
+    active: production
 local-metrics-url: http://localhost:8086
 local-metrics-database: ceres
 local-metrics-rp: autogen


### PR DESCRIPTION
# What

To avoid confusion, we're consolidating onto just `application.yaml` in the Ceres apps and defaulting the jar's profile activation to "production".

The spring-boot maven plugin was already configured to activate "development,raw-data-consumer"